### PR TITLE
Bug - Issue 11 - Jwt too old

### DIFF
--- a/interface/src/redux/container_data/containerData.effects.ts
+++ b/interface/src/redux/container_data/containerData.effects.ts
@@ -14,8 +14,9 @@ import { collectionSuccessOverview, ressourceCollectionSuccess, containerLoadFin
 import { checkContainerOverviewData, checkContainerStats } from "../monitoring_events/monitoringEvents.actions";
 import { Dispatch } from "redux";
 import { IAPIOverviewData, IAPIStatsData } from "../../types/api_response/container.types";
-import { HubConnection } from "@microsoft/signalr";
+import {HttpError, HubConnection} from "@microsoft/signalr";
 import {startInspectDataListening} from "../inspect_container/inspectContainer.effects";
+import {removeJwt} from "../user/user.actions";
 
 export const dataCollectionStart = () => {
   return (dispatch: any, getState: any) => {
@@ -25,6 +26,20 @@ export const dataCollectionStart = () => {
       dispatch(startCollectingRessources());
       dispatch(startListeningForCommandResponses());
       dispatch(startInspectDataListening());
+    }).catch((e: HttpError) => {
+      if(e.statusCode == 401) {
+        dispatch(removeJwt());
+        dispatch(
+            enqueueSnackbar({
+              message: "Invalid or old login token, please login again",
+              options: {
+                key: new Date().getTime() + Math.random(),
+                variant: "error",
+                persist: false,
+              },
+            })
+        );
+      }
     });
   };
 };


### PR DESCRIPTION
When the token gets too old or otherwise invalid, the socket throws an unhandled unauthorized exception. This exception is now caught, and the user is notified that the token is invalid and should be renewed. The invalid token is removed from storage and therefore the frontpage shows as if there never was a token.